### PR TITLE
fix: use `templatefile` function instead of Template Provider

### DIFF
--- a/web-service.tf
+++ b/web-service.tf
@@ -1,7 +1,3 @@
-data "template_file" "user_data" {
-  template = file("userdata.yaml")
-}
-
 resource "aws_instance" "vpc_a_web_hosts" {
   count                       = 3
   ami                         = data.aws_ami.amazon-linux-2.id
@@ -13,7 +9,7 @@ resource "aws_instance" "vpc_a_web_hosts" {
   tags = {
     Name = "spoke-vpc-a/web-host-${count.index}"
   }
-  user_data = data.template_file.user_data.rendered
+  user_data = base64encode(templatefile("userdata.yaml", {}))
 }
 
 resource "aws_security_group" "spoke_vpc_a_web_service_sg" {


### PR DESCRIPTION
*Issue #, if available:*
Thanks for awesome sample!

*Description of changes:*
I failed `terraform init` because of deprecated [Template Provider](https://registry.terraform.io/providers/hashicorp/template/latest/docs)

```zsh
~/Desktop/aws-network-firewall-terraform
$ terraform --version
Terraform v1.4.4
on darwin_arm64
+ provider registry.terraform.io/hashicorp/aws v4.63.0
+ provider registry.terraform.io/hashicorp/random v3.5.1

~/Desktop/aws-network-firewall-terraform
$ terraform init

Initializing the backend...

Initializing provider plugins...
- Reusing previous version of hashicorp/random from the dependency lock file
- Reusing previous version of hashicorp/aws from the dependency lock file
- Finding latest version of hashicorp/template...
- Using previously-installed hashicorp/random v3.5.1
- Using previously-installed hashicorp/aws v4.63.0
╷
│ Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a
│ package available for your current platform, darwin_arm64.
│ 
│ Provider releases are separate from Terraform CLI releases, so not all
│ providers are available for all platforms. Other versions of this provider
│ may have different platforms supported.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
