### PR TITLE
Bugfix: Add bucket ownership controls

### DIFF
--- a/firewall.tf
+++ b/firewall.tf
@@ -160,9 +160,11 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
   }
 }
 
-resource "aws_s3_bucket_acl" "example_bucket_acl" {
+resource "aws_s3_bucket_ownership_controls" "anfw_flow_bucket_ownership_control" {
   bucket = aws_s3_bucket.anfw_flow_bucket.id
-  acl    = "private"
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "anfw_flow_bucket_public_access_block" {


### PR DESCRIPTION
*Issue #, if available:* #8

*Description of changes:* Removes the bucket ACL and adds a `aws_s3_bucket_ownership_controls` applied to the flow logs bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
