### PR TITLE
Implement Cloudwatch Dashboard for Network Firewall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ git-ignored/
 .terraform
 *.tfstate
 *.tfplan
+*.tfvars
 *.backup
 *.hcl
 backend.tf

--- a/cloudwatch_dashboard/README.md
+++ b/cloudwatch_dashboard/README.md
@@ -1,0 +1,257 @@
+# AWS Network Firewall CloudWatch Dashboard
+
+## License:
+
+This sample code is made available under the MIT-0 license. See the LICENSE file.
+
+## Summary:
+
+AWS Network Firewall provides a number of tools that you can use to monitor the utilization, availability, and performance of your firewall. Firewall stateless and stateful engine metrics are published in near real-time to Amazon CloudWatch.  CloudWatch alarms can monitor these metrics and send notifications or take actions when a defined threshold is breached.  Configuring logging for the firewall's stateful engine is optional but highly recommended.  Firewall flow and alert logs provide a wealth of information related to network traffic and stateful drop, reject, and alert rule matches.  Publishing firewall flow and alert log events to CloudWatch log groups allows you to take advantage of CloudWatch log analytics tools such as Logs Insights and Contributor Insights.
+
+Included in this project is a Network Firewall CloudWatch dashboard Terraform configuration.  This easy-to-use configuration creates a monitoring dashboard for a single AWS Network Firewall with just a few commands.  Through a single pane of glass, you will be able to visualize and analyze firewall metric and log data in a structured way.  The included dashboard widgets provide insight into areas such as:
+
+* Gateway Load Balancer endpoint [metrics](https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-cloudwatch-metrics.html)
+* Firewall engine [metrics](https://docs.aws.amazon.com/network-firewall/latest/developerguide/monitoring-cloudwatch.html)
+* Top talkers
+* Top protocols
+* Alert log analysis
+* HTTP & TLS flow analysis
+
+## Pricing Considerations:
+
+The AWS Network Firewall CloudWatch dashboard incorporates a number of CloudWatch features including basic monitoring metrics, [vended logs](https://aws.amazon.com/cloudwatch/pricing/#Vended_Logs), Logs Insights queries, Contributor Insights rules, and the dashboard itself.  Please refer to the [Amazon CloudWatch Pricing](https://aws.amazon.com/cloudwatch/pricing/) guide for up-to-date free and paid tier pricing considerations.  By default, the dashboard will query firewall flow and alert log events over a 3 hour time range.  Increasing the time range will scan more log events at an increased cost while reducing the time range will scan fewer log events at a reduced cost.  All of the Logs Insights and Contributor Insights widgets display the top 10 data points by default.  You can choose to edit the Insights queries or change the Top Contributors to a larger value in order to display more results.  The dashboard will not automatically refresh the widget data by default.  You can choose to manually refresh the data within a single widget or all widgets or you can optionally configure the entire dashboard to automatically refresh at a configured time interval.
+
+## Before You Begin
+
+The provided Terraform configuration makes the following two assumptions:
+
+1.  You have already created an AWS Network Firewall in your VPC
+2.  Your AWS Network Firewall has been configured to publish firewall flow and alert logs to two different CloudWatch log groups.  For example, firewall flow logs are published to /my-firewall-flow-logs and alert logs are published to /my-firewall-alert-logs.
+
+If you have not deployed AWS Network Firewall in your VPC, you can use one of the available [AWS Network Firewall Deployment Architecture](https://github.com/aws-samples/aws-networkfirewall-cfn-templates) templates to create a firewall.  Once created, configure [CloudWatch log groups](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html) for the firewall flow and alert logs and configure stateful [logging](https://docs.aws.amazon.com/network-firewall/latest/developerguide/firewall-logging.html) as described above.  Fine tune your firewall policy and rule configuration and make sure you are routing traffic symmetrically through the firewall.  With the firewall now in the routed path and publishing metrics and log events, you can now proceed with this AWS Network Firewall CloudWatch dashboard Terraform configuration.
+
+## Installation
+
+The AWS Network Firewall dashboard Terraform configuration will create a monitoring dashboard for a single AWS Network Firewall.  You will deploy this configuration in the same region as your firewall.
+
+### Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.0
+- AWS CLI configured with appropriate permissions
+- An existing AWS Network Firewall with flow and alert logging configured
+
+### Deployment Steps
+
+1. **Clone or download this repository**
+   ```bash
+   git clone <repository-url>
+   cd aws-network-firewall-terraform/cloudwatch_dashboard
+   ```
+
+2. **Create a terraform.tfvars file**
+   ```bash
+   cp terraform.tfvars.example terraform.tfvars
+   ```
+   
+   Edit the `terraform.tfvars` file with your specific values:
+   ```hcl
+   firewall_name                   = "my-network-firewall"
+   firewall_subnet_list           = ["subnet-12345678", "subnet-87654321"]
+   firewall_flow_log_group_name   = "/aws/networkfirewall/flowlogs"
+   firewall_alert_log_group_name  = "/aws/networkfirewall/alertlogs"
+   contributor_insights_rule_state = "ENABLED"
+   
+   tags = {
+     Environment = "production"
+     Project     = "network-security"
+   }
+   ```
+
+3. **Initialize Terraform**
+   ```bash
+   terraform init
+   ```
+
+4. **Plan the deployment**
+   ```bash
+   terraform plan
+   ```
+
+5. **Apply the configuration**
+   ```bash
+   terraform apply
+   ```
+
+When deploying, you will need to provide the following variables:
+
+* **firewall_name:**  Firewall name as seen in the **VPC > Network Firewall > Firewalls** console
+* **firewall_subnet_list:**  The firewall subnet IDs to which your firewall endpoints are attached.  The firewall subnets can be found on the **Firewall details** tab of your firewall in the **VPC > Network Firewall > Firewalls** console.
+* **firewall_flow_log_group_name:**  The name of the CloudWatch log group where your firewall flow logs are stored
+* **firewall_alert_log_group_name:**  The name of the CloudWatch log group where your firewall alert logs are stored
+
+Once the deployment is complete, the dashboard URL will be displayed in the output. You can also find it in the CloudWatch Dashboards console. Note that it can take a few minutes for the Logs Insights and Contributor Insights widgets to display data. Some widgets may not display data points if you don't have log events that match the query parameters.
+
+## Removal
+
+You can delete the AWS Network Firewall CloudWatch dashboard and all of the associated resources with a single command.  Deleting the dashboard will not impact the routing and network traffic inspection performed by the firewall.
+
+```bash
+terraform destroy
+```
+
+## Multi-Region and Multi-Partition Support
+
+This Terraform configuration automatically detects the AWS partition (standard, China, or GovCloud) and adjusts the console URLs accordingly. The configuration supports deployment in:
+
+- **AWS Standard Regions** (console.aws.amazon.com)
+- **AWS China Regions** (console.amazonaws.cn) 
+- **AWS GovCloud Regions** (console.amazonaws-us-gov.com)
+
+## Configuration Files
+
+The Terraform configuration is organized into several files:
+
+- **main.tf** - Data sources and local values
+- **variables.tf** - Input variable definitions
+- **outputs.tf** - Output definitions
+- **dashboard.tf** - Main dashboard resource
+- **dashboard_widgets.tf** - Additional dashboard widgets
+- **contributor_insights.tf** - CloudWatch Contributor Insights rules
+- **terraform.tfvars.example** - Example variables file
+
+## Dashboard Widget Details:
+
+### Firewall Endpoints:
+
+|Widget Name | Type | Usage|
+|------|------|------|
+|Firewall Endpoint ENI (GWLBe/VPCe) Metrics | Metrics | Per-endpoint packet, byte, and connections metrics|
+|Per Endpoint Utilization Gbps | Metrics | Per-endpoint utilization in Gbps during the most recent period|
+|ActiveConnections | Metrics | Active connections per-endpoint during the most recent period and time range|
+|BytesProcessed | Metrics | Bytes processed per-endpoint during the most recent period and time range|
+
+### Firewall Engines:
+
+#### Stateless:
+
+|Widget Name | Type | Usage|
+|------|------|------|
+|Stateless Engine Metrics | Metrics | All available stateless engine metrics per availability zone|
+|Stateless Passed Packets | Metrics | Packets passed by stateless rules or default action during the most recent period and time range|
+|Stateless Dropped Packets - Rule Action | Metrics | Packets dropped by stateless rules or stateless default action during the most recent period and time range|
+|Stateless Dropped Packets - Other | Metrics | Packets dropped by stateless packet validation checks during the most recent period and time range|
+
+#### Stateful:
+
+|Widget Name | Type | Usage|
+|------|------|------|
+|Stateful Engine Metrics | Metrics | All available stateful engine metrics per availability zone|
+|Stateful Passed Packets | Metrics | Packets passed by stateful rules or default action during the most recent period and time range|
+|Stateful Dropped Packets | Metrics | Packets dropped by stateful rules or stateful default action during the most recent period and time range|
+|Stateful Rejected Packets | Metrics | Packets rejected due to Reject stateful rule action during the most recent period and time range|
+|TLS Inspection | Metrics | Displays all available SSL/TLS metrics related to [inbound/outbound TLS inspection configurations](https://docs.aws.amazon.com/network-firewall/latest/developerguide/tls-inspection-configurations.html)|
+|Stream Exception Policy Packets| Metrics | Displays count of packets related to long-lived established connections that the receiving firewall appliance is seeing mid-conversation.  The chosen [stream exception policy](https://docs.aws.amazon.com/network-firewall/latest/developerguide/stream-exception-policy.html) action determines how the firewall handles these midstream packets.|
+|Top Long-Lived TCP Flows - Age > 350s | Contributor Insights | Count of TCP flows active for longer than the Gateway Load Balancer's 350 second idle timeout.  This can be used to identify long-lived TCP flows that may be affected by the chosen stream exception policy action.|
+|Top TCP Flows - SYN Without SYN-ACK | Contributor Insights | Count of flows failing the TCP 3-way handshake.  During initial firewall configuration, this might be a sign of misconfigured routing in the return path.  Failing to received a SYN-ACK from the server can also be due to Network ACL, security group, or on-premises firewall rules.|
+
+### Top Talkers
+
+|Widget Name | Type | Usage|
+|------|------|------|
+|Top Source IP by Packets | Contributor Insights | Sum of packets by Source IP|
+|Top Source IP by Bytes | Contributor Insights | Sum of bytes by Source IP|
+|Top Destination IP by Packets | Contributor Insights | Sum of packets by Destination IP|
+|Top Destination IP by Bytes | Contributor Insights | Sum of bytes by Destination IP|
+|Top Source and Destination IP by Packets | Contributor Insights | Sum of packets by Source and Destination IP|
+|Top Source and Destination IP by Bytes | Contributor Insights | Sum of bytes by Source and Destination IP|
+
+### Top Protocols
+
+|Widget Name | Type | Usage|
+|------|------|------|
+|Top Protocols | Logs Insights | Count of top protocols|
+|Top Application Layer Protocols Detected | Logs Insights | Count of top application layer protocols automatically detected by Suricata|
+|Top Source Port| Contributor Insights | Count of top source ports|
+|Top Destination Port| Contributor Insights | Count of top destination ports|
+|Top TCP Flows| Contributor Insights | Count of TCP flows based on source IP, destination IP, and destination port|
+|Top TCP Flows by Packets| Contributor Insights | Sum of packets for TCP flows based on source IP, destination IP, and destination port|
+|Top TCP Flows by Bytes| Contributor Insights | Sum of bytes for TCP flows based on source IP, destination IP, and destination port|
+|Top TCP Flags| Logs Insights | Top TCP flag combinations from firewall flow logs represented in hexadecimal form.  For example, an established and gracefully terminated connection is represented as 1b which equals 27 in decimal.  This equates to FIN (1) + SYN (2) + PSH (8) + ACK (16) flag control bits being set.
+|Top UDP Flows| Contributor Insights | Count of UDP flows based on source IP, destination IP, and destination port|
+|Top UDP Flows by Packets| Contributor Insights | Sum of packets for UDP flows based on source IP, destination IP, and destination port|
+|Top UDP Flows by Bytes| Contributor Insights | Sum of bytes for UDP flows based on source IP, destination IP, and destination port|
+|Top ICMP Flows| Contributor Insights | Count of ICMP flows based on source and destination IP|
+
+### Alert Log Analysis
+
+#### Rule Summary
+
+|Widget Name | Type | Usage|
+|------|------|------|
+|Top Drop/Reject Rules | Logs Insights | Count of drop/reject rule action matches by signature ID, message, and protocol|
+|Top Alert Rules | Logs Insights | Count of alert rule action matches by signature ID, message, and protocol.  Note that alert action rule matches do not also equal pass.|
+|Recent Alert Log Events| Logs Insights | Recent alert log events by timestamp.  A single alert log row can be expanded to view the entire log message.|
+|Top Blocked Source IPs | Logs Insights | Count of source IPs where the rule action is blocked.|
+|Top Blocked Destination IPs | Logs Insights | Count of Destination IPs where the rule action was blocked.|
+|Top Blocked Destination Ports | Logs Insights | Count of destination ports where the rule action was blocked.|
+|Top Blocked Remote Access Ports - Telnet, SSH, RDP | Contributor Insights | Count of flows to destination port 22, 23, or 3389 where the rule action was blocked.|
+|Top blocked TCP Flows | Contributor Insights | Count of TCP flows where the rule action is blocked.|
+|Top blocked UDP Flows | Contributor Insights | Count of UDP flows where the rule action is blocked.|
+
+#### HTTP & TLS
+
+|Widget Name | Type | Usage|
+|------|------|------|
+|Top HTTP Host Header | Contributor Insights | Count of top HTTP hostnames where rule action is not blocked.  Using strict order, you can insert alert rules above pass rules in order to generate HTTP alert log events.  You can use this information to help identify hostnames to include in domain list rule groups or custom Suricata rules.|
+|Top Blocked HTTP Host Header| Contributor Insights | Count of hostnames for blocked HTTP requests.|
+|Top HTTP URI Paths | Contributor Insights | Count of URI paths seen in HTTP requests.|
+|Top HTTP User-Agents | Contributor Insights | Count of user-agents seen in HTTP requests.|
+|Top TLS SNI | Contributor Insights | Count of top server names where rule action is not blocked.  Using strict order, you can insert alert rules above pass rules in order to generate TLS alert log events.  You can use this information to help identify server names to include in domain list rule groups or custom Suricata rules.|
+|Top Blocked SNI| Contributor Insights | Count of SNI for blocked TLS requests.|
+|Top PrivateLink Endpoint Candidates (S3, DynamoDB, & Backup) | Logs Insights | Highlights HTTP/TLS calls to high throughput AWS services such as S3.  Implementing a Gateway or Interface endpoint for these services may be more cost effective than routing this traffic through AWS Network Firewall.|
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Dashboard widgets not showing data**
+   - Ensure your firewall is actively processing traffic
+   - Verify that flow and alert logging are properly configured
+   - Check that the log group names are correct
+   - Wait a few minutes for data to populate
+
+2. **Contributor Insights rules not working**
+   - Verify that the `contributor_insights_rule_state` is set to "ENABLED"
+   - Check that log events are being published to the specified log groups
+   - Ensure the log format matches the expected structure
+
+3. **Permission errors**
+   - Verify that your AWS credentials have the necessary permissions for CloudWatch, Logs, and Contributor Insights
+   - Check that the Terraform execution role has appropriate permissions
+
+### Useful Commands
+
+```bash
+# Check Terraform state
+terraform show
+
+# Validate configuration
+terraform validate
+
+# Format configuration files
+terraform fmt
+
+# Show planned changes
+terraform plan
+
+# Apply specific resources
+terraform apply -target=aws_cloudwatch_dashboard.firewall_dashboard
+```
+
+## Resources
+
+For more information about developing applications using Terraform and AWS CloudWatch, see:
+
+- [Terraform AWS Provider Documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
+- [AWS CloudWatch User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/)
+- [AWS Network Firewall Developer Guide](https://docs.aws.amazon.com/network-firewall/latest/developerguide/)

--- a/cloudwatch_dashboard/contributor_insights.tf
+++ b/cloudwatch_dashboard/contributor_insights.tf
@@ -1,0 +1,734 @@
+# Contributor Insights Rules for AWS Network Firewall CloudWatch Dashboard
+
+# Top Long-Lived TCP Flows - Age > 350 Seconds
+resource "aws_cloudwatch_contributor_insight_rule" "top_long_lived_tcp_flows" {
+  rule_name  = "TopLongLivedTCPFlowsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.src_port",
+        "$.event.dest_ip",
+        "$.event.dest_port"
+      ]
+      Filters = [
+        {
+          Match       = "$.event.netflow.age"
+          GreaterThan = 350
+        },
+        {
+          Match = "$.event.proto"
+          In    = ["TCP"]
+        }
+      ]
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# TCP SYN Without SYN-ACK
+resource "aws_cloudwatch_contributor_insight_rule" "top_tcp_syn_without_synack" {
+  rule_name  = "TopTCPSYNWithoutSYNACKRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.src_port",
+        "$.event.dest_ip",
+        "$.event.dest_port"
+      ]
+      Filters = [
+        {
+          Match = "$.event.tcp.tcp_flags"
+          In    = ["02"]
+        }
+      ]
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top Source IP by Packets
+resource "aws_cloudwatch_contributor_insight_rule" "top_source_ip_by_packets" {
+  rule_name  = "TopSourceIPByPacketsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys    = ["$.event.src_ip"]
+      ValueOf = "$.event.netflow.pkts"
+      Filters = []
+    }
+    AggregateOn = "Sum"
+  })
+
+  tags = var.tags
+}
+
+# Top Source IP by Bytes
+resource "aws_cloudwatch_contributor_insight_rule" "top_source_ip_by_bytes" {
+  rule_name  = "TopSourceIPByBytesRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys    = ["$.event.src_ip"]
+      ValueOf = "$.event.netflow.bytes"
+      Filters = []
+    }
+    AggregateOn = "Sum"
+  })
+
+  tags = var.tags
+}
+
+# Top Destination IP by Packets
+resource "aws_cloudwatch_contributor_insight_rule" "top_destination_ip_by_packets" {
+  rule_name  = "TopDestinationIPByPacketsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys    = ["$.event.dest_ip"]
+      ValueOf = "$.event.netflow.pkts"
+      Filters = []
+    }
+    AggregateOn = "Sum"
+  })
+
+  tags = var.tags
+}
+
+# Top Destination IP by Bytes
+resource "aws_cloudwatch_contributor_insight_rule" "top_destination_ip_by_bytes" {
+  rule_name  = "TopDestinationIPByBytesRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys    = ["$.event.dest_ip"]
+      ValueOf = "$.event.netflow.bytes"
+      Filters = []
+    }
+    AggregateOn = "Sum"
+  })
+
+  tags = var.tags
+}
+
+# Top Source and Destination IP by Packets
+resource "aws_cloudwatch_contributor_insight_rule" "top_source_and_destination_ip_by_packets" {
+  rule_name  = "TopSourceAndDestinationIPByPacketsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.dest_ip"
+      ]
+      ValueOf = "$.event.netflow.pkts"
+      Filters = []
+    }
+    AggregateOn = "Sum"
+  })
+
+  tags = var.tags
+}
+
+# Top Source and Destination IP by Bytes
+resource "aws_cloudwatch_contributor_insight_rule" "top_source_and_destination_ip_by_bytes" {
+  rule_name  = "TopSourceAndDestinationIPByBytesRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.dest_ip"
+      ]
+      ValueOf = "$.event.netflow.bytes"
+      Filters = []
+    }
+    AggregateOn = "Sum"
+  })
+
+  tags = var.tags
+}
+
+# Top Source Ports
+resource "aws_cloudwatch_contributor_insight_rule" "top_source_ports" {
+  rule_name  = "TopSourcePortsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys    = ["$.event.src_port"]
+      Filters = []
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top Destination Ports
+resource "aws_cloudwatch_contributor_insight_rule" "top_destination_ports" {
+  rule_name  = "TopDestinationPortsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys    = ["$.event.dest_port"]
+      Filters = []
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top TCP Flows
+resource "aws_cloudwatch_contributor_insight_rule" "top_tcp_flows" {
+  rule_name  = "TopTCPFlowsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.dest_ip",
+        "$.event.dest_port"
+      ]
+      Filters = [
+        {
+          Match = "$.event.proto"
+          In    = ["TCP"]
+        }
+      ]
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top TCP Flows by Packets
+resource "aws_cloudwatch_contributor_insight_rule" "top_tcp_flows_by_packets" {
+  rule_name  = "TopTCPFlowsByPacketsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.dest_ip",
+        "$.event.dest_port"
+      ]
+      ValueOf = "$.event.netflow.pkts"
+      Filters = [
+        {
+          Match = "$.event.proto"
+          In    = ["TCP"]
+        }
+      ]
+    }
+    AggregateOn = "Sum"
+  })
+
+  tags = var.tags
+}
+
+# Top TCP Flows by Bytes
+resource "aws_cloudwatch_contributor_insight_rule" "top_tcp_flows_by_bytes" {
+  rule_name  = "TopTCPFlowsByBytesRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.dest_ip",
+        "$.event.dest_port"
+      ]
+      ValueOf = "$.event.netflow.bytes"
+      Filters = [
+        {
+          Match = "$.event.proto"
+          In    = ["TCP"]
+        }
+      ]
+    }
+    AggregateOn = "Sum"
+  })
+
+  tags = var.tags
+}
+
+# Top UDP Flows
+resource "aws_cloudwatch_contributor_insight_rule" "top_udp_flows" {
+  rule_name  = "TopUDPFlowsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.dest_ip",
+        "$.event.dest_port"
+      ]
+      Filters = [
+        {
+          Match = "$.event.proto"
+          In    = ["UDP"]
+        }
+      ]
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top UDP Flows by Packets
+resource "aws_cloudwatch_contributor_insight_rule" "top_udp_flows_by_packets" {
+  rule_name  = "TopUDPFlowsByPacketsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.dest_ip",
+        "$.event.dest_port"
+      ]
+      ValueOf = "$.event.netflow.pkts"
+      Filters = [
+        {
+          Match = "$.event.proto"
+          In    = ["UDP"]
+        }
+      ]
+    }
+    AggregateOn = "Sum"
+  })
+
+  tags = var.tags
+}
+
+# Top UDP Flows by Bytes
+resource "aws_cloudwatch_contributor_insight_rule" "top_udp_flows_by_bytes" {
+  rule_name  = "TopUDPFlowsByBytesRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.dest_ip",
+        "$.event.dest_port"
+      ]
+      ValueOf = "$.event.netflow.bytes"
+      Filters = [
+        {
+          Match = "$.event.proto"
+          In    = ["UDP"]
+        }
+      ]
+    }
+    AggregateOn = "Sum"
+  })
+
+  tags = var.tags
+}
+
+# Top ICMP Flows
+resource "aws_cloudwatch_contributor_insight_rule" "top_icmp_flows" {
+  rule_name  = "TopICMPFlowsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_flow_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.dest_ip"
+      ]
+      Filters = [
+        {
+          Match = "$.event.proto"
+          In    = ["ICMP"]
+        }
+      ]
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top Blocked Remote Access Ports (SSH, Telnet, RDP)
+resource "aws_cloudwatch_contributor_insight_rule" "top_blocked_remote_access_ports" {
+  rule_name  = "TopBlockedRemoteAccessPortsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_alert_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.dest_ip",
+        "$.event.dest_port"
+      ]
+      Filters = [
+        {
+          Match = "$.event.alert.action"
+          In    = ["blocked"]
+        },
+        {
+          Match = "$.event.dest_port"
+          In    = ["22", "23", "3389"]
+        }
+      ]
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top Blocked TCP Flows
+resource "aws_cloudwatch_contributor_insight_rule" "top_blocked_tcp_flows" {
+  rule_name  = "TopBlockedTCPFlowsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_alert_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.dest_ip",
+        "$.event.dest_port"
+      ]
+      Filters = [
+        {
+          Match = "$.event.alert.action"
+          In    = ["blocked"]
+        },
+        {
+          Match = "$.event.proto"
+          In    = ["TCP"]
+        }
+      ]
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top Blocked UDP Flows
+resource "aws_cloudwatch_contributor_insight_rule" "top_blocked_udp_flows" {
+  rule_name  = "TopBlockedUDPFlowsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_alert_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = [
+        "$.event.src_ip",
+        "$.event.dest_ip",
+        "$.event.dest_port"
+      ]
+      Filters = [
+        {
+          Match = "$.event.alert.action"
+          In    = ["blocked"]
+        },
+        {
+          Match = "$.event.proto"
+          In    = ["UDP"]
+        }
+      ]
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top HTTP Host Header
+resource "aws_cloudwatch_contributor_insight_rule" "top_http_host_header" {
+  rule_name  = "TopHTTPHostHeaderRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_alert_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = ["$.event.http.hostname"]
+      Filters = [
+        {
+          Match = "$.event.alert.action"
+          NotIn = ["blocked"]
+        }
+      ]
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top Blocked HTTP Host Header
+resource "aws_cloudwatch_contributor_insight_rule" "top_blocked_http_host_header" {
+  rule_name  = "TopBlockedHTTPHostHeaderRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_alert_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = ["$.event.http.hostname"]
+      Filters = [
+        {
+          Match = "$.event.alert.action"
+          In    = ["blocked"]
+        }
+      ]
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top HTTP URI Paths
+resource "aws_cloudwatch_contributor_insight_rule" "top_http_uri_paths" {
+  rule_name  = "TopHTTPURIPathsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_alert_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys    = ["$.event.http.url"]
+      Filters = []
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top HTTP User-Agents
+resource "aws_cloudwatch_contributor_insight_rule" "top_http_user_agents" {
+  rule_name  = "TopHTTPUserAgentsRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_alert_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys    = ["$.event.http.http_user_agent"]
+      Filters = []
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top TLS SNI
+resource "aws_cloudwatch_contributor_insight_rule" "top_tls_sni" {
+  rule_name  = "TopTLSSNIRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_alert_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = ["$.event.tls.sni"]
+      Filters = [
+        {
+          Match = "$.event.alert.action"
+          NotIn = ["blocked"]
+        }
+      ]
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}
+
+# Top Blocked TLS SNI
+resource "aws_cloudwatch_contributor_insight_rule" "top_blocked_tls_sni" {
+  rule_name  = "TopBlockedTLSSNIRule-${var.firewall_name}"
+  rule_state = var.contributor_insights_rule_state
+
+  rule_definition = jsonencode({
+    Schema = {
+      Name    = "CloudWatchLogRule"
+      Version = 1
+    }
+    LogGroupNames = [var.firewall_alert_log_group_name]
+    LogFormat     = "JSON"
+    Contribution = {
+      Keys = ["$.event.tls.sni"]
+      Filters = [
+        {
+          Match = "$.event.alert.action"
+          In    = ["blocked"]
+        }
+      ]
+    }
+    AggregateOn = "Count"
+  })
+
+  tags = var.tags
+}

--- a/cloudwatch_dashboard/dashboard.tf
+++ b/cloudwatch_dashboard/dashboard.tf
@@ -1,0 +1,518 @@
+# CloudWatch Dashboard for AWS Network Firewall
+
+resource "aws_cloudwatch_dashboard" "firewall_dashboard" {
+  dashboard_name = "${var.firewall_name}-dashboard-tf"
+
+  dashboard_body = jsonencode({
+    widgets = concat([
+      # Overview Section
+      {
+        height = 2
+        width  = 24
+        y      = 0
+        x      = 0
+        type   = "text"
+        properties = {
+          markdown   = "# Overview\n[button:primary:Firewall Console](${local.console_url}/vpc/home?region=${data.aws_region.current.name}#NetworkFirewallDetails:arn=${local.arn_pattern}_network-firewall_${data.aws_region.current.name}_${data.aws_caller_identity.current.account_id}_firewall~${var.firewall_name}) [button:Troubleshooting](https://docs.aws.amazon.com/network-firewall/latest/developerguide/troubleshooting.html) [button:re&#58;Post](https://repost.aws/search/content?globalSearch=network%20firewall)"
+          background = "transparent"
+        }
+      },
+
+      # Firewall Endpoints Section Header
+      {
+        height = 1
+        width  = 24
+        y      = 2
+        x      = 0
+        type   = "text"
+        properties = {
+          markdown   = "# Firewall Endpoints"
+          background = "transparent"
+        }
+      },
+
+      # Firewall Endpoint ENI Metrics
+      {
+        height = 7
+        width  = 6
+        y      = 3
+        x      = 0
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH(' Namespace=\"AWS/PrivateLinkEndpoints\" ${local.subnet_query_string}', 'Sum', 300)"
+              label      = "$${!PROP('Dim.VPC Endpoint Id')}  $${!PROP('MetricName')}"
+              id         = "e1"
+              region     = data.aws_region.current.name
+            }]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = data.aws_region.current.name
+          stat    = "Sum"
+          period  = 300
+          title   = "Firewall Endpoint ENI (GWLBe/VPCe) Metrics"
+          legend = {
+            position = "bottom"
+          }
+        }
+      },
+
+      # Per Endpoint Utilization
+      {
+        height = 7
+        width  = 6
+        y      = 3
+        x      = 6
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "((m1/300)/.008)"
+              label      = "$${!PROP('Dim.VPC Endpoint Id')}"
+              id         = "e1"
+              period     = 300
+              stat       = "Sum"
+              region     = data.aws_region.current.name
+            }],
+            [{
+              expression = "SEARCH('Namespace=\"AWS/PrivateLinkEndpoints\" ${local.subnet_query_string} MetricName=\"BytesProcessed\"', 'Sum', 300)"
+              label      = "Expression1"
+              id         = "m1"
+              region     = data.aws_region.current.name
+              visible    = false
+            }]
+          ]
+          view    = "gauge"
+          stacked = true
+          region  = data.aws_region.current.name
+          stat    = "Sum"
+          period  = 60
+          title   = "Per Endpoint Utilization Gbps"
+          yAxis = {
+            left = {
+              min = 0
+              max = 100000000000
+            }
+          }
+          setPeriodToTimeRange = false
+          sparkline            = true
+          trend                = true
+        }
+      },
+
+      # Active Connections
+      {
+        height = 7
+        width  = 6
+        y      = 3
+        x      = 12
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH('Namespace=\"AWS/PrivateLinkEndpoints\" ${local.subnet_query_string} MetricName=\"ActiveConnections\"', 'Sum', 300)"
+              label      = "$${!PROP('Dim.VPC Endpoint Id')}  $${!PROP('MetricName')}"
+              id         = "m1"
+              region     = data.aws_region.current.name
+              visible    = true
+            }]
+          ]
+          sparkline = true
+          view      = "singleValue"
+          region    = data.aws_region.current.name
+          period    = 300
+          stat      = "Sum"
+          title     = "ActiveConnections"
+        }
+      },
+
+      # Bytes Processed
+      {
+        height = 7
+        width  = 6
+        y      = 3
+        x      = 18
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH('Namespace=\"AWS/PrivateLinkEndpoints\" ${local.subnet_query_string} MetricName=\"BytesProcessed\"', 'Sum', 300)"
+              label      = "$${!PROP('Dim.VPC Endpoint Id')}  $${!PROP('MetricName')}"
+              id         = "m2"
+              region     = data.aws_region.current.name
+              visible    = true
+            }]
+          ]
+          sparkline = true
+          view      = "singleValue"
+          region    = data.aws_region.current.name
+          period    = 300
+          stat      = "Sum"
+          title     = "BytesProcessed"
+        }
+      },
+
+      # Firewall Engines Section Header
+      {
+        height = 1
+        width  = 24
+        y      = 10
+        x      = 0
+        type   = "text"
+        properties = {
+          markdown   = "# Firewall Engines"
+          background = "transparent"
+        }
+      },
+
+      # Stateless Section Header
+      {
+        height = 1
+        width  = 24
+        y      = 11
+        x      = 0
+        type   = "text"
+        properties = {
+          markdown   = "## Stateless"
+          background = "transparent"
+        }
+      },
+
+      # Stateless Engine Metrics
+      {
+        height = 7
+        width  = 6
+        y      = 12
+        x      = 0
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH('Namespace=\"AWS/NetworkFirewall\" FirewallName=\"${var.firewall_name}\" Engine=\"Stateless\"', 'Sum')"
+              label      = ""
+              id         = "e1"
+              region     = data.aws_region.current.name
+            }]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = data.aws_region.current.name
+          stat    = "Sum"
+          period  = 300
+          title   = "Stateless Engine Metrics"
+          legend = {
+            position = "bottom"
+          }
+        }
+      },
+
+      # Stateless Passed Packets
+      {
+        height = 7
+        width  = 6
+        y      = 12
+        x      = 6
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH('Namespace=\"AWS/NetworkFirewall\" FirewallName=\"${var.firewall_name}\" Engine=\"Stateless\" MetricName=\"PassedPackets\"', 'Sum', 300)"
+              label      = "$${!PROP('Dim.AvailabilityZone')} $${!PROP('MetricName')}"
+              id         = "e1"
+              region     = data.aws_region.current.name
+            }]
+          ]
+          sparkline = true
+          view      = "singleValue"
+          region    = data.aws_region.current.name
+          title     = "Stateless Passed Packets"
+          period    = 300
+          stat      = "Sum"
+        }
+      },
+
+      # Stateless Dropped Packets - Rule Action
+      {
+        height = 7
+        width  = 6
+        y      = 12
+        x      = 12
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH('Namespace=\"AWS/NetworkFirewall\" FirewallName=\"${var.firewall_name}\" Engine=\"Stateless\" MetricName=\"DroppedPackets\"', 'Sum', 300)"
+              label      = "$${!PROP('Dim.AvailabilityZone')} $${!PROP('MetricName')}"
+              id         = "e1"
+              region     = data.aws_region.current.name
+            }]
+          ]
+          sparkline = true
+          view      = "singleValue"
+          region    = data.aws_region.current.name
+          title     = "Stateless Dropped Packets - Rule Action"
+          period    = 300
+          stat      = "Sum"
+        }
+      },
+
+      # Stateless Dropped Packets - Other
+      {
+        height = 7
+        width  = 6
+        y      = 12
+        x      = 18
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH('Namespace=\"AWS/NetworkFirewall\" FirewallName=\"${var.firewall_name}\" Engine=\"Stateless\" MetricName=Other OR Invalid', 'Sum', 300)"
+              label      = "$${!PROP('Dim.AvailabilityZone')} $${!PROP('MetricName')}"
+              id         = "e1"
+              region     = data.aws_region.current.name
+            }]
+          ]
+          sparkline = true
+          view      = "singleValue"
+          region    = data.aws_region.current.name
+          title     = "Stateless Dropped Packets - Other"
+          period    = 300
+          stat      = "Sum"
+        }
+      },
+
+      # Stateful Section Header
+      {
+        height = 1
+        width  = 24
+        y      = 19
+        x      = 0
+        type   = "text"
+        properties = {
+          markdown   = "## Stateful"
+          background = "transparent"
+        }
+      },
+
+      # Stateful Engine Metrics
+      {
+        height = 7
+        width  = 6
+        y      = 20
+        x      = 0
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH('Namespace=\"AWS/NetworkFirewall\" FirewallName=\"${var.firewall_name}\" Engine=\"Stateful\"', 'Sum')"
+              label      = ""
+              id         = "e1"
+              region     = data.aws_region.current.name
+            }]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = data.aws_region.current.name
+          stat    = "Sum"
+          period  = 300
+          title   = "Stateful Engine Metrics"
+        }
+      },
+
+      # Stateful Passed Packets
+      {
+        height = 7
+        width  = 6
+        y      = 20
+        x      = 6
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH('Namespace=\"AWS/NetworkFirewall\" FirewallName=\"${var.firewall_name}\" Engine=\"Stateful\" MetricName=\"PassedPackets\"', 'Sum', 300)"
+              label      = "$${!PROP('Dim.AvailabilityZone')} $${!PROP('MetricName')}"
+              id         = "e1"
+              region     = data.aws_region.current.name
+            }]
+          ]
+          sparkline = true
+          view      = "singleValue"
+          region    = data.aws_region.current.name
+          period    = 300
+          stat      = "Sum"
+          title     = "Stateful Passed Packets"
+        }
+      },
+
+      # Stateful Dropped Packets
+      {
+        height = 7
+        width  = 6
+        y      = 20
+        x      = 12
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH('Namespace=\"AWS/NetworkFirewall\" FirewallName=\"${var.firewall_name}\" Engine=\"Stateful\" MetricName=\"DroppedPackets\"', 'Sum', 300)"
+              label      = "$${!PROP('Dim.AvailabilityZone')} $${!PROP('MetricName')}"
+              id         = "e1"
+              region     = data.aws_region.current.name
+            }]
+          ]
+          sparkline = true
+          view      = "singleValue"
+          region    = data.aws_region.current.name
+          period    = 300
+          stat      = "Sum"
+          title     = "Stateful Dropped Packets"
+        }
+      },
+
+      # Stateful Rejected Packets
+      {
+        height = 7
+        width  = 6
+        y      = 20
+        x      = 18
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH('Namespace=\"AWS/NetworkFirewall\" FirewallName=\"${var.firewall_name}\" Engine=\"Stateful\" MetricName=\"RejectedPackets\"', 'Sum', 300)"
+              label      = "$${!PROP('Dim.AvailabilityZone')} $${!PROP('MetricName')}"
+              id         = "e1"
+              region     = data.aws_region.current.name
+            }]
+          ]
+          sparkline = true
+          view      = "singleValue"
+          region    = data.aws_region.current.name
+          period    = 300
+          stat      = "Sum"
+          title     = "Stateful Rejected Packets"
+        }
+      },
+
+      # TLS Inspection
+      {
+        height = 7
+        width  = 6
+        y      = 27
+        x      = 0
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH('Namespace=\"AWS/NetworkFirewall\" FirewallName=\"${var.firewall_name}\" MetricName=TLS', 'Sum', 300)"
+              label      = "$${!PROP('Dim.AvailabilityZone')} $${!PROP('MetricName')}"
+              id         = "e1"
+              region     = data.aws_region.current.name
+            }]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = data.aws_region.current.name
+          stat    = "Sum"
+          period  = 300
+          title   = "TLS Inspection"
+        }
+      },
+
+      # Stream Exception Policy Packets
+      {
+        height = 7
+        width  = 6
+        y      = 27
+        x      = 6
+        type   = "metric"
+        properties = {
+          metrics = [
+            [{
+              expression = "SEARCH('Namespace=\"AWS/NetworkFirewall\" FirewallName=\"${var.firewall_name}\" MetricName=\"StreamExceptionPolicyPackets\"', 'Sum', 300)"
+              label      = "$${!PROP('Dim.AvailabilityZone')} $${!PROP('MetricName')}"
+              id         = "e1"
+              region     = data.aws_region.current.name
+            }]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = data.aws_region.current.name
+          stat    = "Sum"
+          period  = 300
+          title   = "Stream Exception Policy Packets"
+        }
+      },
+
+      # Top Long-Lived TCP Flows
+      {
+        height = 7
+        width  = 6
+        y      = 27
+        x      = 12
+        type   = "metric"
+        properties = {
+          period = 60
+          insightRule = {
+            maxContributorCount = 10
+            orderBy             = "Sum"
+            ruleName            = aws_cloudwatch_contributor_insight_rule.top_long_lived_tcp_flows.rule_name
+          }
+          stacked = false
+          view    = "timeSeries"
+          yAxis = {
+            left = {
+              showUnits = false
+            }
+            right = {
+              showUnits = false
+            }
+          }
+          region = data.aws_region.current.name
+          title  = "Top Long-Lived TCP Flows - Age > 350s"
+          legend = {
+            position = "right"
+          }
+        }
+      },
+
+      # Top TCP Flows - SYN Without SYN-ACK
+      {
+        height = 7
+        width  = 6
+        y      = 27
+        x      = 18
+        type   = "metric"
+        properties = {
+          period = 60
+          insightRule = {
+            maxContributorCount = 10
+            orderBy             = "Sum"
+            ruleName            = aws_cloudwatch_contributor_insight_rule.top_tcp_syn_without_synack.rule_name
+          }
+          stacked = false
+          view    = "timeSeries"
+          yAxis = {
+            left = {
+              showUnits = false
+            }
+            right = {
+              showUnits = false
+            }
+          }
+          region = data.aws_region.current.name
+          title  = "Top TCP Flows - SYN Without SYN-ACK"
+          legend = {
+            position = "right"
+          }
+        }
+      }
+    ], local.additional_widgets)
+  })
+
+  depends_on = [
+    aws_cloudwatch_contributor_insight_rule.top_blocked_tls_sni
+  ]
+}

--- a/cloudwatch_dashboard/dashboard_widgets.tf
+++ b/cloudwatch_dashboard/dashboard_widgets.tf
@@ -1,0 +1,869 @@
+# Additional dashboard widgets - this file contains the remaining widgets for the dashboard
+
+locals {
+  # Additional widgets for the dashboard
+  additional_widgets = [
+    # Top Talkers Section Header
+    {
+      height = 1
+      width  = 24
+      y      = 34
+      x      = 0
+      type   = "text"
+      properties = {
+        markdown   = "# Top Talkers"
+        background = "transparent"
+      }
+    },
+
+    # Top Source IP by Packets
+    {
+      height = 7
+      width  = 6
+      y      = 35
+      x      = 0
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top Source IP by Packets"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_source_ip_by_packets.rule_name
+        }
+      }
+    },
+
+    # Top Source IP by Bytes
+    {
+      height = 7
+      width  = 6
+      y      = 35
+      x      = 6
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top Source IP by Bytes"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_source_ip_by_bytes.rule_name
+        }
+      }
+    },
+
+    # Top Destination IP by Packets
+    {
+      height = 7
+      width  = 6
+      y      = 35
+      x      = 12
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top Destination IP by Packets"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_destination_ip_by_packets.rule_name
+        }
+      }
+    },
+
+    # Top Destination IP by Bytes
+    {
+      height = 7
+      width  = 6
+      y      = 35
+      x      = 18
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top Destination IP by Bytes"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_destination_ip_by_bytes.rule_name
+        }
+      }
+    },
+
+    # Top Source and Destination IP by Packets
+    {
+      height = 7
+      width  = 12
+      y      = 42
+      x      = 0
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top Source and Destination IP by Packets"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_source_and_destination_ip_by_packets.rule_name
+        }
+      }
+    },
+
+    # Top Source and Destination IP by Bytes
+    {
+      height = 7
+      width  = 12
+      y      = 42
+      x      = 12
+      type   = "metric"
+      properties = {
+        period = 60
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_source_and_destination_ip_by_bytes.rule_name
+        }
+        stacked = false
+        view    = "timeSeries"
+        yAxis = {
+          left = {
+            showUnits = false
+          }
+          right = {
+            showUnits = false
+          }
+        }
+        region = data.aws_region.current.name
+        title  = "Top Source and Destination IP by Bytes"
+        legend = {
+          position = "right"
+        }
+      }
+    },
+
+    # Top Protocols Section Header
+    {
+      height = 1
+      width  = 24
+      y      = 49
+      x      = 0
+      type   = "text"
+      properties = {
+        markdown   = "# Top Protocols"
+        background = "transparent"
+      }
+    },
+
+    # Top Protocols
+    {
+      height = 7
+      width  = 6
+      y      = 50
+      x      = 0
+      type   = "log"
+      properties = {
+        query   = "SOURCE '${var.firewall_flow_log_group_name}' | stats count() as proto by event.proto\n| sort proto desc\n| limit 10"
+        region  = data.aws_region.current.name
+        stacked = false
+        title   = "Top Protocols"
+        view    = "pie"
+      }
+    },
+
+    # Top Application Layer Protocols Detected
+    {
+      height = 7
+      width  = 6
+      y      = 50
+      x      = 6
+      type   = "log"
+      properties = {
+        query   = "SOURCE '${var.firewall_flow_log_group_name}' | stats count() as app_proto by event.app_proto\n| sort app_proto desc\n| limit 10"
+        region  = data.aws_region.current.name
+        stacked = false
+        view    = "pie"
+        title   = "Top Application Layer Protocols Detected"
+      }
+    },
+
+    # Top Source Port
+    {
+      height = 7
+      width  = 6
+      y      = 50
+      x      = 12
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top Source Port"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_source_ports.rule_name
+        }
+      }
+    },
+
+    # Top Destination Port
+    {
+      height = 7
+      width  = 6
+      y      = 50
+      x      = 18
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top Destination Port"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_destination_ports.rule_name
+        }
+      }
+    },
+
+    # Top TCP Flows
+    {
+      height = 7
+      width  = 6
+      y      = 57
+      x      = 0
+      type   = "metric"
+      properties = {
+        period = 60
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_tcp_flows.rule_name
+        }
+        stacked = false
+        view    = "timeSeries"
+        yAxis = {
+          left = {
+            showUnits = false
+          }
+          right = {
+            showUnits = false
+          }
+        }
+        region = data.aws_region.current.name
+        title  = "Top TCP Flows"
+        legend = {
+          position = "right"
+        }
+      }
+    },
+
+    # Top TCP Flows by Packets
+    {
+      height = 7
+      width  = 6
+      y      = 57
+      x      = 6
+      type   = "metric"
+      properties = {
+        period = 60
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_tcp_flows_by_packets.rule_name
+        }
+        stacked = false
+        view    = "timeSeries"
+        yAxis = {
+          left = {
+            showUnits = false
+          }
+          right = {
+            showUnits = false
+          }
+        }
+        region = data.aws_region.current.name
+        title  = "Top TCP Flows by Packets"
+        legend = {
+          position = "right"
+        }
+      }
+    },
+
+    # Top TCP Flows by Bytes
+    {
+      height = 7
+      width  = 6
+      y      = 57
+      x      = 12
+      type   = "metric"
+      properties = {
+        period = 60
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_tcp_flows_by_bytes.rule_name
+        }
+        stacked = false
+        view    = "timeSeries"
+        yAxis = {
+          left = {
+            showUnits = false
+          }
+          right = {
+            showUnits = false
+          }
+        }
+        region = data.aws_region.current.name
+        title  = "Top TCP Flows by Bytes"
+        legend = {
+          position = "right"
+        }
+      }
+    },
+
+    # Top TCP Flags
+    {
+      height = 7
+      width  = 6
+      y      = 57
+      x      = 18
+      type   = "log"
+      properties = {
+        query  = "SOURCE '${var.firewall_flow_log_group_name}' | stats count() as tcp_flags by event.tcp.tcp_flags\n| sort tcp_flags desc\n| limit 10"
+        region = data.aws_region.current.name
+        title  = "Top TCP Flags"
+        view   = "pie"
+      }
+    },
+
+    # Top UDP Flows
+    {
+      height = 7
+      width  = 6
+      y      = 64
+      x      = 0
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top UDP Flows"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_udp_flows.rule_name
+        }
+      }
+    },
+
+    # Top UDP Flows by Packets
+    {
+      height = 7
+      width  = 6
+      y      = 64
+      x      = 6
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top UDP Flows by Packets"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_udp_flows_by_packets.rule_name
+        }
+      }
+    },
+
+    # Top UDP Flows by Bytes
+    {
+      height = 7
+      width  = 6
+      y      = 64
+      x      = 12
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top UDP Flows by Bytes"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_udp_flows_by_bytes.rule_name
+        }
+      }
+    },
+
+    # Top ICMP Flows
+    {
+      height = 7
+      width  = 6
+      y      = 64
+      x      = 18
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top ICMP Flows"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_icmp_flows.rule_name
+        }
+      }
+    },
+
+    # Alert Log Analysis Section Header
+    {
+      height = 1
+      width  = 24
+      y      = 71
+      x      = 0
+      type   = "text"
+      properties = {
+        markdown   = "# Alert Log Analysis"
+        background = "transparent"
+      }
+    },
+
+    # Rule Summary Section Header
+    {
+      height = 1
+      width  = 24
+      y      = 72
+      x      = 0
+      type   = "text"
+      properties = {
+        markdown   = "## Rule Summary"
+        background = "transparent"
+      }
+    },
+
+    # Top Drop/Reject Rules
+    {
+      height = 7
+      width  = 6
+      y      = 73
+      x      = 0
+      type   = "log"
+      properties = {
+        query   = "SOURCE '${var.firewall_alert_log_group_name}' | stats count (*) as Count by event.alert.signature_id as SID, event.alert.action as Action, event.alert.signature as Message, event.proto as Proto\n| display SID, Action, Message, Proto, Count\n| filter event.alert.action = 'blocked'\n| sort Count desc\n| limit 10"
+        region  = data.aws_region.current.name
+        stacked = false
+        title   = "Top Drop/Reject Rules"
+        view    = "table"
+      }
+    },
+
+    # Top Alert Rules
+    {
+      height = 7
+      width  = 6
+      y      = 73
+      x      = 6
+      type   = "log"
+      properties = {
+        query   = "SOURCE '${var.firewall_alert_log_group_name}' | stats count (*) as Count by event.alert.signature_id as SID, event.alert.action as Action, event.alert.signature as Message, event.proto as Proto\n| display SID, Action, Message, Proto, Count\n| filter event.alert.action != 'blocked'\n| sort Count desc\n| limit 10"
+        region  = data.aws_region.current.name
+        stacked = false
+        title   = "Top Alert Rules"
+        view    = "table"
+      }
+    },
+
+    # Recent Alert Log Events
+    {
+      height = 7
+      width  = 12
+      y      = 73
+      x      = 12
+      type   = "log"
+      properties = {
+        query   = "SOURCE '${var.firewall_alert_log_group_name}' | fields event.timestamp as Time, event.alert.signature_id as SID, event.alert.signature as Message, event.proto as Proto, event.src_ip as Src_IP, event.src_port as Src_Port, event.dest_ip as Dest_IP, event.dest_port as Dest_Port\n| sort event.timestamp desc\n| limit 10"
+        region  = data.aws_region.current.name
+        stacked = false
+        title   = "Recent Alert Log Events"
+        view    = "table"
+      }
+    },
+
+    # Top Blocked Source IPs
+    {
+      height = 7
+      width  = 6
+      y      = 80
+      x      = 0
+      type   = "log"
+      properties = {
+        query  = "SOURCE '${var.firewall_alert_log_group_name}' | stats count() as blocked_src_ip by event.src_ip as src_ip\n| filter event.alert.action = 'blocked'\n| sort blocked_src_ip desc\n| limit 10"
+        region = data.aws_region.current.name
+        title  = "Top Blocked Source IPs"
+        view   = "pie"
+      }
+    },
+
+    # Top Blocked Destination IPs
+    {
+      height = 7
+      width  = 6
+      y      = 80
+      x      = 6
+      type   = "log"
+      properties = {
+        query  = "SOURCE '${var.firewall_alert_log_group_name}' | stats count() as blocked_dest_ip by event.dest_ip as dest_ip\n| filter event.alert.action = 'blocked'\n| sort blocked_dest_ip desc\n| limit 10"
+        region = data.aws_region.current.name
+        title  = "Top Blocked Destination IPs"
+        view   = "pie"
+      }
+    },
+
+    # Top Blocked Destination Ports
+    {
+      height = 7
+      width  = 6
+      y      = 80
+      x      = 12
+      type   = "log"
+      properties = {
+        query   = "SOURCE '${var.firewall_alert_log_group_name}' | stats count() as blocked_dest_port by event.dest_port as dest_port\n| filter event.alert.action = 'blocked'\n| sort blocked_dest_port desc\n| limit 10"
+        region  = data.aws_region.current.name
+        stacked = false
+        title   = "Top Blocked Destination Ports"
+        view    = "pie"
+      }
+    },
+
+    # Top Blocked Remote Access Ports
+    {
+      height = 7
+      width  = 6
+      y      = 80
+      x      = 18
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top Blocked Remote Access Ports - Telnet, SSH, RDP"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_blocked_remote_access_ports.rule_name
+        }
+      }
+    },
+
+    # Top Blocked TCP Flows
+    {
+      height = 7
+      width  = 12
+      y      = 87
+      x      = 0
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top Blocked TCP Flows"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_blocked_tcp_flows.rule_name
+        }
+      }
+    },
+
+    # Top Blocked UDP Flows
+    {
+      type   = "metric"
+      height = 7
+      width  = 12
+      y      = 87
+      x      = 12
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top Blocked UDP Flows"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_blocked_udp_flows.rule_name
+        }
+      }
+    },
+
+    # HTTP & TLS Section Header
+    {
+      height = 1
+      width  = 24
+      y      = 94
+      x      = 0
+      type   = "text"
+      properties = {
+        markdown   = "## HTTP & TLS"
+        background = "transparent"
+      }
+    },
+
+    # Top HTTP Host Header
+    {
+      height = 7
+      width  = 6
+      y      = 95
+      x      = 0
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top HTTP Host Header"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_http_host_header.rule_name
+        }
+      }
+    },
+
+    # Top Blocked HTTP Host Header
+    {
+      height = 7
+      width  = 6
+      y      = 95
+      x      = 6
+      type   = "metric"
+      properties = {
+        period = 60
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_blocked_http_host_header.rule_name
+        }
+        stacked = false
+        view    = "timeSeries"
+        yAxis = {
+          left = {
+            showUnits = false
+          }
+          right = {
+            showUnits = false
+          }
+        }
+        region = data.aws_region.current.name
+        title  = "Top Blocked HTTP Host Header"
+        legend = {
+          position = "right"
+        }
+      }
+    },
+
+    # Top HTTP URI Paths
+    {
+      height = 7
+      width  = 6
+      y      = 95
+      x      = 12
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top HTTP URI Paths"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_http_uri_paths.rule_name
+        }
+      }
+    },
+
+    # Top HTTP User-Agents
+    {
+      height = 7
+      width  = 6
+      y      = 95
+      x      = 18
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top HTTP User-Agents"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_http_user_agents.rule_name
+        }
+      }
+    },
+
+    # Top TLS SNI
+    {
+      height = 7
+      width  = 6
+      y      = 102
+      x      = 0
+      type   = "metric"
+      properties = {
+        period   = 60
+        region   = data.aws_region.current.name
+        stacked  = false
+        timezone = "local"
+        title    = "Top TLS SNI"
+        view     = "timeSeries"
+        legend = {
+          position = "right"
+        }
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_tls_sni.rule_name
+        }
+      }
+    },
+
+    # Top Blocked TLS SNI
+    {
+      height = 7
+      width  = 6
+      y      = 102
+      x      = 6
+      type   = "metric"
+      properties = {
+        period = 60
+        insightRule = {
+          maxContributorCount = 10
+          orderBy             = "Sum"
+          ruleName            = aws_cloudwatch_contributor_insight_rule.top_blocked_tls_sni.rule_name
+        }
+        stacked = false
+        view    = "timeSeries"
+        yAxis = {
+          left = {
+            showUnits = false
+          }
+          right = {
+            showUnits = false
+          }
+        }
+        region = data.aws_region.current.name
+        title  = "Top Blocked TLS SNI"
+        legend = {
+          position = "right"
+        }
+      }
+    },
+
+    # Top PrivateLink Endpoint Candidates
+    {
+      height = 7
+      width  = 12
+      y      = 102
+      x      = 12
+      type   = "log"
+      properties = {
+        query  = "SOURCE '${var.firewall_alert_log_group_name}' | stats count(*) as Count by event.src_ip as Source_IP, event.dest_ip as Dest_IP, event.app_proto as App_Proto, event.tls.sni as SNI, event.http.hostname as Hostname\n| filter event.tls.sni like \"s3\" or event.http.hostname like \"s3\" or event.tls.sni like \"dynamodb\" or event.http.hostname like \"dynamodb\" or event.tls.sni like \"backup\" or event.http.hostname like \"backup\"\n| display Source_IP, Dest_IP, App_Proto, SNI, Hostname, Count\n| sort Count desc\n| limit 10"
+        region = data.aws_region.current.name
+        title  = "Top PrivateLink Endpoint Candidates (S3, DynamoDB, & Backup)"
+        view   = "table"
+      }
+    }
+  ]
+}

--- a/cloudwatch_dashboard/main.tf
+++ b/cloudwatch_dashboard/main.tf
@@ -1,0 +1,36 @@
+# AWS Network Firewall CloudWatch Dashboard
+
+# Data sources
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# Local values for subnet query string generation
+locals {
+  subnet_query_parts  = [for subnet in var.firewall_subnet_list : "\"Subnet Id\"=\"${subnet}\""]
+  subnet_query_string = join(" OR ", local.subnet_query_parts)
+
+  # Console URLs for different partitions
+  console_urls = {
+    "aws"        = "https://console.aws.amazon.com"
+    "aws-cn"     = "https://${data.aws_region.current.name}.console.amazonaws.cn"
+    "aws-us-gov" = "https://${data.aws_region.current.name}.console.amazonaws-us-gov.com"
+  }
+
+  # ARN patterns for different partitions
+  arn_patterns = {
+    "aws"        = "arn:aws"
+    "aws-cn"     = "arn:aws-cn"
+    "aws-us-gov" = "arn:aws-us-gov"
+  }
+
+  # Get partition from region
+  partition = split("-", data.aws_region.current.name)[0] == "cn" ? "aws-cn" : (
+    contains(["us-gov-east-1", "us-gov-west-1"], data.aws_region.current.name) ? "aws-us-gov" : "aws"
+  )
+
+  console_url = local.console_urls[local.partition]
+  arn_pattern = local.arn_patterns[local.partition]
+
+  # Log resource ARN pattern based on partition
+  log_resource_arn = "${local.arn_pattern}:logs:*:*:*"
+}

--- a/cloudwatch_dashboard/outputs.tf
+++ b/cloudwatch_dashboard/outputs.tf
@@ -1,0 +1,43 @@
+# Outputs for AWS Network Firewall CloudWatch Dashboard
+
+output "firewall_dashboard_uri" {
+  description = "Link to the CloudWatch Dashboard"
+  value       = "${local.console_url}/cloudwatch/home?region=${data.aws_region.current.name}#dashboards:name=${aws_cloudwatch_dashboard.firewall_dashboard.dashboard_name}"
+}
+
+output "dashboard_name" {
+  description = "Name of the created CloudWatch Dashboard"
+  value       = aws_cloudwatch_dashboard.firewall_dashboard.dashboard_name
+}
+
+output "contributor_insights_rules" {
+  description = "List of created Contributor Insights rules"
+  value = [
+    aws_cloudwatch_contributor_insight_rule.top_long_lived_tcp_flows.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_tcp_syn_without_synack.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_source_ip_by_packets.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_source_ip_by_bytes.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_destination_ip_by_packets.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_destination_ip_by_bytes.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_source_and_destination_ip_by_packets.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_source_and_destination_ip_by_bytes.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_source_ports.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_destination_ports.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_tcp_flows.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_tcp_flows_by_packets.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_tcp_flows_by_bytes.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_udp_flows.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_udp_flows_by_packets.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_udp_flows_by_bytes.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_icmp_flows.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_blocked_remote_access_ports.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_blocked_tcp_flows.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_blocked_udp_flows.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_http_host_header.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_blocked_http_host_header.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_http_uri_paths.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_http_user_agents.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_tls_sni.rule_name,
+    aws_cloudwatch_contributor_insight_rule.top_blocked_tls_sni.rule_name
+  ]
+}

--- a/cloudwatch_dashboard/terraform.tfvars.example
+++ b/cloudwatch_dashboard/terraform.tfvars.example
@@ -1,0 +1,46 @@
+# AWS Network Firewall CloudWatch Dashboard Configuration
+# Copy this file to terraform.tfvars and update with your specific values
+
+# Required Variables
+firewall_name                   = "my-network-firewall"
+firewall_subnet_list           = ["subnet-12345678", "subnet-87654321"]
+firewall_flow_log_group_name   = "/aws/networkfirewall/flowlogs"
+firewall_alert_log_group_name  = "/aws/networkfirewall/alertlogs"
+
+# Optional Variables
+contributor_insights_rule_state = "ENABLED"  # Options: ENABLED, DISABLED
+
+# Tags (optional)
+tags = {
+  Environment = "production"
+  Project     = "network-security"
+  Owner       = "security-team"
+  CostCenter  = "12345"
+}
+
+# Example configurations for different environments:
+
+# Development Environment
+# firewall_name                   = "dev-network-firewall"
+# firewall_subnet_list           = ["subnet-dev123", "subnet-dev456"]
+# firewall_flow_log_group_name   = "/aws/networkfirewall/dev/flowlogs"
+# firewall_alert_log_group_name  = "/aws/networkfirewall/dev/alertlogs"
+# contributor_insights_rule_state = "DISABLED"
+# tags = {
+#   Terraform   = "true"
+#   Environment = "development"
+#   Project     = "network-security"
+# }
+
+# Production Environment
+# firewall_name                   = "prod-network-firewall"
+# firewall_subnet_list           = ["subnet-prod123", "subnet-prod456", "subnet-prod789"]
+# firewall_flow_log_group_name   = "/aws/networkfirewall/prod/flowlogs"
+# firewall_alert_log_group_name  = "/aws/networkfirewall/prod/alertlogs"
+# contributor_insights_rule_state = "ENABLED"
+# tags = {
+#   Terraform   = "true"
+#   Environment = "production"
+#   Project     = "network-security"
+#   Compliance  = "required"
+# }

--- a/cloudwatch_dashboard/variables.tf
+++ b/cloudwatch_dashboard/variables.tf
@@ -1,0 +1,41 @@
+# Variables for AWS Network Firewall CloudWatch Dashboard
+
+variable "firewall_name" {
+  description = "Enter the firewall name as seen in the firewall console"
+  type        = string
+}
+
+variable "firewall_subnet_list" {
+  description = "Select the firewall endpoint subnet(s)"
+  type        = list(string)
+  validation {
+    condition     = length(var.firewall_subnet_list) > 0
+    error_message = "At least one firewall subnet must be specified."
+  }
+}
+
+variable "firewall_flow_log_group_name" {
+  description = "Name of the CloudWatch log group where your firewall flow logs are stored"
+  type        = string
+}
+
+variable "firewall_alert_log_group_name" {
+  description = "Name of the CloudWatch log group where your firewall alert logs are stored"
+  type        = string
+}
+
+variable "contributor_insights_rule_state" {
+  description = "State of the Contributor Insight rules - ENABLED rules actively process logs, DISABLED rules are created but inactive"
+  type        = string
+  default     = "ENABLED"
+  validation {
+    condition     = contains(["ENABLED", "DISABLED"], var.contributor_insights_rule_state)
+    error_message = "Contributor Insights rule state must be either ENABLED or DISABLED."
+  }
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resources"
+  type        = map(string)
+  default     = {}
+}

--- a/cloudwatch_dashboard/versions.tf
+++ b/cloudwatch_dashboard/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
*Description of changes:*
This change implements the Cloudwatch Dashboard from [aws-samples/aws-networkfirewall-cfn-templates](https://github.com/aws-samples/aws-networkfirewall-cfn-templates/tree/main/cloudwatch_dashboard)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
